### PR TITLE
ensure app is started & compatibilty for Ansible 2.9

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Check if use systemd"
-  set_fact: use_system_d={{(ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8', '>=')) or (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version | version_compare('7', '>=')) or (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15', '>=')) }}
+  set_fact: use_system_d={{(ansible_distribution == 'Debian' and ansible_distribution_version is version_compare('8', '>=')) or (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version is version_compare('7', '>=')) or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version_compare('15', '>=')) }}
 
 - name: "Ensure systemd system directory is present (for Ubuntu)"
   file:

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -27,4 +27,3 @@
     daemon-reload: yes
     state: restarted
   when: use_system_d
-

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -19,3 +19,12 @@
   when: use_system_d
   notify:
     - "Restart application"
+
+- name: "Ensure application started"
+  systemd:
+    name: "{{ springboot_application_name }}"
+    enabled: yes
+    daemon-reload: yes
+    state: restarted
+  when: use_system_d
+

--- a/templates/app.service.j2
+++ b/templates/app.service.j2
@@ -6,6 +6,7 @@ After=syslog.target
 User={{ springboot_user }}
 ExecStart="{{ springboot_deploy_folder }}/{{ springboot_application_name }}.jar"
 SuccessExitStatus=143
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I had an issue with this role as the app was not properly started with handler due to later issue in playbook and handler was not retrigger after, so I propose to add a task start.
there is a a deprecation notice, I fixed it.